### PR TITLE
doc patch

### DIFF
--- a/lib/Test/Mock/Redis.pm
+++ b/lib/Test/Mock/Redis.pm
@@ -38,7 +38,14 @@ This module is designed to function as a drop in replacement for
 Redis.pm for testing purposes.
 
 See perldoc Redis and the redis documentation at L<http://redis.io>
-    
+
+=head1 PERSISTENCE
+
+The "connection" to the mocked server (and its stored data) will persist beyond
+the object instance, just like a real Redis server. This means that you do not
+need to save the instance to this object in order to preserve your data; simply
+call C<new> with the same server parameter and the same instance will be
+returned, with all data preserved.
 
 =head1 SUBROUTINES/METHODS
 


### PR DESCRIPTION
specifically note in the docs that data lives beyond the lifetime of the associated object instance -- I found this out by accident, after writing a hook in my app that saved the Test::Mock::Redis object so I wouldn't lose data.  It's obvious in hindsight (otherwise it wouldn't really mirror the functionality of a real Redis instance), but I think this is important to note it in the docs.

thanks again for this distribution; it is very handy :)
