### PR TITLE
check keys for existence before returning

### DIFF
--- a/Changes
+++ b/Changes
@@ -16,3 +16,6 @@ Revision history for Test-Mock-Redis
         Correct type is returned for non-existent keys (RT#76534, Karen
         Etheridge)
 
+0.09
+        Expired keys are not returned in the KEYS list (Karen Etheridge)
+

--- a/lib/Test/Mock/Redis.pm
+++ b/lib/Test/Mock/Redis.pm
@@ -326,7 +326,10 @@ sub keys :method {
     $match =~ s/(?<!\\)\*/.*/g;
     $match =~ s/(?<!\\)\?/.?/g;
 
-    return @{[ sort { $a cmp $b } grep { /$match/ } keys %{ $self->_stash }]};
+    return @{[ sort { $a cmp $b }
+        grep { exists $self->_stash->{$_} }
+        grep { /$match/ }
+        keys %{ $self->_stash }]};
 }
 
 sub randomkey {

--- a/t/07-expires.t
+++ b/t/07-expires.t
@@ -38,6 +38,8 @@ foreach my $r (@redi){
 
     sleep 2;
 
+    is_deeply([ $r->keys('*') ], [ qw(baz foo) ], 'expired key removed from KEYS list');
+
     ok(! $r->exists('bar'), 'bar expired');
 
     ok(! $r->expireat('quizlebub', time + 1), "expireat on a key that doesn't exist returns false");


### PR DESCRIPTION
In real redis, all data is removed when a key expires; this patch removes expired keys from the 'KEYS' list by checking for existence (which removes expired data in the tied hash).

PS. "PossiblyVolitile" should probably be "PossiblyVolatile" :)
