### PR TITLE
these commands return "OK", not an integer (verified with 2.4 and 2.6 servers)

### DIFF
--- a/Changes
+++ b/Changes
@@ -23,16 +23,22 @@ Revision history for Test-Mock-Redis
 0.09    Feb 26 2013
         Expired keys are not returned in the KEYS list (Karen Etheridge)
 
-0.10    
+0.10
         'info' output brought up-to-date w/redis 2.6
 
         fixed output for these commands: (Karen Etheridge)
-            auth
-            set
-            setex
-            mset
-            rename
-            ltrim
-            lset
-            select
-            save
+            should return OK, not 1:
+                auth
+                set
+                setex
+                mset
+                rename
+                ltrim
+                lset
+                select
+                save
+            should return a list length, not the list itself:
+                rpush
+                lpush
+                rpushx
+                lpushx

--- a/lib/Test/Mock/Redis.pm
+++ b/lib/Test/Mock/Redis.pm
@@ -375,7 +375,8 @@ sub rpush {
 
     $self->_make_list($key);
 
-    return push @{ $self->_stash->{$key} }, "$value";
+    push @{ $self->_stash->{$key} }, "$value";
+    return scalar @{ $self->_stash->{$key} };
 }
 
 sub lpush {
@@ -386,7 +387,8 @@ sub lpush {
 
     $self->_make_list($key);
 
-    return unshift @{ $self->_stash->{$key} }, "$value";
+    unshift @{ $self->_stash->{$key} }, "$value";
+    return scalar @{ $self->_stash->{$key} };
 }
 
 sub rpushx {
@@ -394,7 +396,8 @@ sub rpushx {
 
     return unless $self->_is_list($key);
 
-    return push @{ $self->_stash->{$key} }, "$value";
+    push @{ $self->_stash->{$key} }, "$value";
+    return scalar @{ $self->_stash->{$key} };
 }
 
 sub lpushx {
@@ -402,7 +405,8 @@ sub lpushx {
 
     return unless $self->_is_list($key);
 
-    return unshift @{ $self->_stash->{$key} }, "$value";
+    unshift @{ $self->_stash->{$key} }, "$value";
+    return scalar @{ $self->_stash->{$key} };
 }
 
 sub llen {


### PR DESCRIPTION
I noticed the return values of these methods didn't match the documentation; I checked on a 2.4 and 2.6 server and they haven't changed -- they always returned 'OK'.
