### PR TITLE
Reformatted Changes file as per CPAN::Changes::Spec

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,32 +1,20 @@
-Revision history for Test-Mock-Redis
+Revision history for Perl module Test::Mock::Redis
 
-0.01    Feb 13 2011
-        First version, released on an unsuspecting world.
+0.14 2013-08-31
 
-0.02    Feb 14 2011
-        More redis functions, including auth, append, strlen, getset, mset & msetnx
+0.13 2013-08-27
 
-0.03    Feb 16 2011
-        Pay attention to the server argument to new - now a singleton per server, just like redis
-        Fixed Test::Exception dependency
+0.12 2013-12-06
+    - support for pipelined calls, using callback subs (Karen Etheridge)
 
-0.04    Feb 18 2011
-        Made error conditions consistent with Redis.pm's behavior
+0.11 2013-18-05
+    - atomic transactions ('multi', 'exec', 'discard') now supported:
+      http://redis.io/topics/transactions (Karen Etheridge)
 
-0.07    Oct  5 2011
-        Fix for RT-71461, incorrect rename behavior
+0.10 2013-16-05
+    - 'info' output brought up-to-date w/redis 2.6
 
-0.08    Apr 13 2012
-        Correct type is returned for non-existent keys (RT#76534, Karen
-        Etheridge)
-
-0.09    Feb 26 2013
-        Expired keys are not returned in the KEYS list (Karen Etheridge)
-
-0.10    May 16 2013
-        'info' output brought up-to-date w/redis 2.6
-
-        fixed output for these commands: (Karen Etheridge)
+    - fixed output for these commands: (Karen Etheridge)
             should return OK, not 1:
                 auth
                 set
@@ -43,9 +31,28 @@ Revision history for Test-Mock-Redis
                 rpushx
                 lpushx
 
-0.11    May 18 2013
-        atomic transactions ('multi', 'exec', 'discard') now supported:
-        http://redis.io/topics/transactions (Karen Etheridge)
+0.09 2013-26-02
+    - Expired keys are not returned in the KEYS list (Karen Etheridge)
 
-0.12    Jun 12 2013
-        support for pipelined calls, using callback subs (Karen Etheridge)
+0.08 2012-13-04
+    - Correct type is returned for non-existent keys
+      (RT#76534, Karen Etheridge)
+
+0.07 2011-05-10
+    - Fix for RT-71461, incorrect rename behavior
+
+0.04 2011-18-02
+    - Made error conditions consistent with Redis.pm's behavior
+
+0.03 2011-16-02
+    - Pay attention to the server argument to new -
+      now a singleton per server, just like redis
+    - Fixed Test::Exception dependency
+
+0.02 2011-14-02
+    - More redis functions, including
+      auth, append, strlen, getset, mset & msetnx
+
+0.01 2011-13-02
+    - First version, released on an unsuspecting world.
+


### PR DESCRIPTION
Hi,

I've reformatted your Changes file according to the spec in CPAN::Changes::Spec. I've reversed the order so most recent release comes first, and added entries for 0.13 and 0.14, which weren't listed.

Following this format means that various tools can more easily process your distribution automatically.

You can find out more about this at Brian Cassidy's [CPAN::Changes Kwalitee Service](http://changes.cpanhq.org), which is where I saw your module listed :-)

Cheers,
Neil

PS I'm doing this because I'm on a quest to help improve CPAN:
        http://questhub.io/realm/perl/quest/51f0337718ba7d3959000086
   You can check the status of your Changes files for all dists:
        http://changes.cpanhq.org/author/JLAVALLEE
   If you choose you update the others, you can log them in comments on the quest :-)
