### PR TITLE
del command delete multiple keys and returns number deleted

### DIFF
--- a/lib/Test/Mock/Redis.pm
+++ b/lib/Test/Mock/Redis.pm
@@ -320,11 +320,14 @@ sub msetnx {
 }
 
 sub del {
-    my ( $self, $key ) = @_;
+    my ( $self, @keys ) = @_;
 
-    my $ret = $self->exists($key);
+    my $ret = 0;
 
-    delete $self->_stash->{$key};
+    for my $key (@keys) {
+        $ret++ if $self->exists($key);
+        delete $self->_stash->{$key};
+    }
 
     return $ret;
 }

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -52,6 +52,8 @@ foreach my $o (@redi){
     ok($o->set('test-undef' => 42), 'set test-undef');
     ok($o->exists('test-undef'), 'exists undef');
 
+
+
     # Big sized keys
     for my $size (10_000, 100_000, 500_000, 1_000_000, 2_500_000) {
       my $v = 'a' x $size;
@@ -87,7 +89,7 @@ foreach my $o (@redi){
       is($o->decrby('test-decrby', 7), -($_ * 7), 'decrby 7');
     }
 
-    ok($o->del($_), "del $_") foreach map {"key-$_"} ('next', 'left');
+    is($o->del(map {"key-$_"} ('next', 'left')), 2, 'del multiple keys');
     ok(!$o->del('non-existing'), 'del non-existing');
 
     is($o->type('zzzzzzz'), 'none', 'type of non-existent key');


### PR DESCRIPTION
The DEL command is specified in http://redis.io/commands/del as taking multiple keys and returning the number that were successfully deleted.
