### PR TITLE
implement zrevrangebyscore

### DIFF
--- a/lib/Test/Mock/Redis.pm
+++ b/lib/Test/Mock/Redis.pm
@@ -999,7 +999,9 @@ sub zrange {
     
     return map { $withscores ? ( $_, $self->zscore($key, $_) ) : $_ } 
                ( map { $_->[0] }
-                     sort { $a->[1] <=> $b->[1] }
+                     sort { $a->[1] <=> $b->[1]
+                                     ||
+                            $a->[0] cmp $b->[0] }
                          map { [ $_, $self->_stash->{$key}->{$_} ] }
                              keys %{ $self->_stash->{$key} } 
                )[$start..$stop]
@@ -1037,7 +1039,13 @@ sub zrangebyscore {
             
     return map { $withscores ? ( $_, $self->zscore($key, $_) ) : $_ } 
                grep { $cmp->($_) } $self->zrange($key, 0, $self->zcard($key)-1);
-                   $self->zrange($key, 0, $self->zcard($key)-1);
+}
+
+# note max and min are reversed from zrangebyscore
+sub zrevrangebyscore {
+    my ( $self, $key, $max, $min, $withscores ) = @_;
+
+    return reverse $self->zrangebyscore($key, $min, $max, $withscores);
 }
 
 sub zcount {

--- a/lib/Test/Mock/Redis.pm
+++ b/lib/Test/Mock/Redis.pm
@@ -1045,7 +1045,10 @@ sub zrangebyscore {
 sub zrevrangebyscore {
     my ( $self, $key, $max, $min, $withscores ) = @_;
 
-    return reverse $self->zrangebyscore($key, $min, $max, $withscores);
+    my $not_with_scores = 0;
+
+    return map { $withscores ? ( $_, $self->zscore($key, $_) ) : $_ } 
+               reverse $self->zrangebyscore($key, $min, $max, $not_with_scores);
 }
 
 sub zcount {

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -242,6 +242,31 @@ foreach my $o (@redi){
     ok($o->del($zset));                          # cleanup
 
 
+    my @sorting_zkeys = (qw/foog foof fooe fooa foob food fooc/);
+
+    # foo* all have the same score so they should sort lexically
+    $o->zadd($zset, 1, 'bar');
+    ok($o->zadd($zset, 5, $_)) for @sorting_zkeys;
+    $o->zadd($zset, 9, 'baz');
+    
+    my @sorted_zkeys = sort @sorting_zkeys;
+    @sorting_zkeys = ('bar', @sorting_zkeys, 'baz');
+    @sorted_zkeys = ('bar', @sorted_zkeys, 'baz');
+
+    is_deeply([$o->zrangebyscore($zset, 0, 10)], \@sorted_zkeys);
+    is_deeply([$o->zrangebyscore($zset, 0, 4)], [ 'bar' ]);
+    is_deeply([$o->zrangebyscore($zset, 2, 6)], [@sorted_zkeys[1..7]]);
+
+    my @revsorted_zkeys = reverse @sorted_zkeys;
+
+    # max and min are reversed
+    is_deeply([$o->zrevrangebyscore($zset, 10, 0)], \@revsorted_zkeys);
+    is_deeply([$o->zrevrangebyscore($zset, 4, 0)], [ 'bar' ]);
+    is_deeply([$o->zrevrangebyscore($zset, 6, 2)], [@revsorted_zkeys[1..7]]);
+
+
+    ok($o->del($zset));                          # cleanup
+
     ## Commands operating on hashes
 
     my $hash = 'test-hash';

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -264,6 +264,12 @@ foreach my $o (@redi){
     is_deeply([$o->zrevrangebyscore($zset, 4, 0)], [ 'bar' ]);
     is_deeply([$o->zrevrangebyscore($zset, 6, 2)], [@revsorted_zkeys[1..7]]);
 
+    # test withscores
+    my $expected_withscores = [ map { $_, 5} @revsorted_zkeys ];
+    # (fix up bar =>1 and baz => 9 by hand)
+    $expected_withscores->[-1] = 1;
+    $expected_withscores->[1] = 9;
+    is_deeply([$o->zrevrangebyscore($zset, 10, 0, 1)], $expected_withscores);
 
     ok($o->del($zset));                          # cleanup
 


### PR DESCRIPTION
Also fix zrangebyscore so it sorts items with the same score in
lexicographic order, taking into account when its called with the 'withscores' parameter. And adds tests for all that.