### PR TITLE
Update hexists to return 1/0 not 1/'' per redis docs.

### DIFF
--- a/lib/Test/Mock/Redis.pm
+++ b/lib/Test/Mock/Redis.pm
@@ -737,7 +737,7 @@ sub hexists {
     confess '[hexists] ERR Operation against a key holding the wrong kind of value'
          if $self->exists($key) and !$self->_is_hash($key);
 
-    return exists $self->_stash->{$key}->{$hkey};
+    return exists $self->_stash->{$key}->{$hkey} ? 1 : 0;
 }
 
 sub hdel {

--- a/t/10-hash.t
+++ b/t/10-hash.t
@@ -78,7 +78,7 @@ foreach my $r (@redi){
 
     ok $r->hset('hash', 'foo', 'foobar'), "hset returns true when it's happy";
 
-    ok $r->hexists('hash', 'foo'), "hexists returns true when it's true";
+    is $r->hexists('hash', 'foo'), 1, "hexists returns 1 when it's true";
 
     ok ! $r->hdel('blarg', 'blorf'), "hdel on a hash that doesn't exist returns false";
     ok ! $r->hdel('hash', 'blarg'),  "hdel on a hash field that doesn't exist returns false";
@@ -86,6 +86,7 @@ foreach my $r (@redi){
     ok $r->hdel('hash', 'foo'), "hdel returns true when it's happy";
 
     ok ! $r->hexists('hash', 'foo'), "hdel really deleted the field";
+    is $r->hexists('hash', 'foo'), 0, "hexists returns 0 when field is not in the hash";
 
     is $r->hlen('hash'), 0, "hlen counted zarro keys";
 
@@ -151,4 +152,3 @@ foreach my $r (@redi){
 
 
 done_testing();
-


### PR DESCRIPTION
Quick fix to have `hexists` return 0 or 1, this will have it match the documented return values of the redis command: http://redis.io/commands/hexists