### PR TITLE
Handle negative indices

### DIFF
--- a/lib/Test/Mock/Redis.pm
+++ b/lib/Test/Mock/Redis.pm
@@ -1013,7 +1013,7 @@ sub zrevrange {
 
     return map { $withscores ? ( $_, $self->zscore($key, $_) ) : $_ }
                ( map { $_->[0] }
-                     sort { $b->[1] <=> $a->[1] }
+                     sort { $b->[1] <=> $a->[1] || $b->[0] cmp $a->[0] }
                          map { [ $_, $self->_stash->{$key}->{$_} ] }
                              keys %{ $self->_stash->{$key} }
                )[$start..$stop]

--- a/lib/Test/Mock/Redis.pm
+++ b/lib/Test/Mock/Redis.pm
@@ -463,26 +463,34 @@ sub llen {
 sub lrange {
     my ( $self, $key, $start, $end ) = @_;
 
-    return @{ $self->_stash->{$key} }[$start..$end];
+    my $array = $self->_stash->{$key};
+    ($start,$end) = _normalize_range(scalar(@$array),$start,$end);
+    return @{ $array }[$start..$end];
 }
 
 sub ltrim {
     my ( $self, $key, $start, $end ) = @_;
 
-    $self->_stash->{$key} = [ @{ $self->_stash->{$key} }[$start..$end] ];
+    my $array = $self->_stash->{$key};
+    ($start,$end) = _normalize_range(scalar(@$array),$start,$end);
+    $self->_stash->{$key} = [ @{ $array }[$start..$end] ];
     return 'OK';
 }
 
 sub lindex {
     my ( $self, $key, $index ) = @_;
 
-    return $self->_stash->{$key}->[$index];
+    my $array = $self->_stash->{$key};
+    $index = _normalize_index(scalar(@$array),$index);
+    return $array->[$index];
 }
 
 sub lset {
     my ( $self, $key, $index, $value ) = @_;
 
-    $self->_stash->{$key}->[$index] = "$value";
+    my $array = $self->_stash->{$key};
+    $index = _normalize_index(scalar(@$array),$index);
+    $array->[$index] = "$value";
     return 'OK';
 }
 
@@ -995,7 +1003,8 @@ sub zrevrank {
 sub zrange {
     my ( $self, $key, $start, $stop, $withscores ) = @_;
 
-    $stop = $self->zcard($key)-1 if $stop >= $self->zcard($key);
+    my $length = $self->zcard($key);
+    ($start,$stop) = _normalize_range($length,$start,$stop);
 
     return map { $withscores ? ( $_, $self->zscore($key, $_) ) : $_ }
                ( map { $_->[0] }
@@ -1009,7 +1018,8 @@ sub zrange {
 sub zrevrange {
     my ( $self, $key, $start, $stop, $withscores ) = @_;
 
-    $stop = $self->zcard($key)-1 if $stop >= $self->zcard($key);
+    my $length = $self->zcard($key);
+    ($start,$stop) = _normalize_range($length,$start,$stop);
 
     return map { $withscores ? ( $_, $self->zscore($key, $_) ) : $_ }
                ( map { $_->[0] }
@@ -1193,6 +1203,22 @@ See L<http://dev.perl.org/licenses/> for more information.
 
 =cut
 
+sub _normalize_index {
+    my ( $length, $index ) = @_;
+
+    $index += $length if $index < 0;
+    return $index;
+}
+
+sub _normalize_range {
+    my ( $length, $start, $end ) = @_;
+
+    $start = _normalize_index($length,$start);
+    $end = _normalize_index($length,$end);
+    $end = $length-1 if $end >= $length;
+
+    return ($start,$end);
+}
 
 sub _is_list {
     my ( $self, $key ) = @_;

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -205,6 +205,8 @@ foreach my $o (@redi){
     is_deeply([$o->zrange($zset, 0, 1)], [qw/bar foo/]);
     is_deeply([$o->zrevrange($zset, 0, 1)], [qw/baz foo/]);
 
+    is_deeply([$o->zrange($zset, 0, -2)], [qw/bar foo/]);
+    is_deeply([$o->zrevrange($zset, -3, 1)], [qw/baz foo/]);
 
     my $withscores = {$o->zrevrange($zset, 0, 1, 'WITHSCORES')};
 

--- a/t/09-list.t
+++ b/t/09-list.t
@@ -16,10 +16,10 @@ x   LLEN
 x   LPOP
 x   LPUSH
 x   LPUSHX
-    LRANGE
+x   LRANGE
     LREM
-    LSET
-    LTRIM
+x   LSET
+x   LTRIM
 x   RPOP
     RPOPLPUSH
 x   RPUSH
@@ -72,6 +72,9 @@ foreach my $r (@redi){
 
     is $r->lindex('list', $_), $_ for 0..9;
 
+    # e.g. lindex('list',-1) returns the last element
+    is $r->lindex('list', -1-$_), 9-$_ for 0..9;
+
     is $r->llen('list'), 10, 'llen returns length of list';
 
     is $r->lpop('list'), $_ for 0..9;
@@ -96,6 +99,23 @@ foreach my $r (@redi){
 
     is $r->rpoplpush(destination => 'destination'), 'z';
     list_exactly_contains($r, destination => 'z', 'c', 'x', 'y');
+
+    is_deeply([$r->lrange(destination => 0, 2)], [qw/z c x/]);
+    is_deeply([$r->lrange(destination => 1, 2)], [qw/c x/]);
+    is_deeply([$r->lrange(destination => 1, -1)], [qw/c x y/]);
+    is_deeply([$r->lrange(destination => 2, -2)], [qw/x/]);
+    is_deeply([$r->lrange(destination => -3, 5)], [qw/c x y/]);
+    is_deeply([$r->lrange(destination => 3, 1)], []);
+
+    $r->lset(destination => 0, 'a');
+    $r->lset(destination => -1, 'f');
+    list_exactly_contains($r, destination => 'a', 'c', 'x', 'f');
+
+    $r->rpush(long => $_) for 1..10;
+    $r->ltrim(long => 1,8);
+    list_exactly_contains($r,long => 2..9);
+    $r->ltrim(long => -5,-3);
+    list_exactly_contains($r,long => 5..7);
 }
 
 sub list_exactly_contains {


### PR DESCRIPTION
Hello! This is a different (and more complete) implementation of #21 
With these changes, every function that accepts indices will accept negative values (I checked the Redis documentation for the expected semantics).
As an extra fix, `zrevrange` now correctly sorts by reverse lexicographical order the elements with the same score.