### PR TITLE
Fix lrem issue with array length changing

### DIFF
--- a/lib/Test/Mock/Redis.pm
+++ b/lib/Test/Mock/Redis.pm
@@ -529,17 +529,22 @@ sub lset {
 sub lrem {
     my ( $self, $key, $count, $value ) = @_;
     my $removed;
-    my @indicies = $count < 0
-                 ? ($#{ $self->_stash->{$key} }..0)
-                 : (0..$#{ $self->_stash->{$key} })
-    ;
+    my @indicies = (0..$#{ $self->_stash->{$key} });
+    @indicies = reverse @indicies if $count < 0;
     $count = abs $count;
 
+    my @to_remove;
     for my $index (@indicies){
         if($self->_stash->{$key}->[$index] eq $value){
-            splice @{ $self->_stash->{$key} }, $index, 1;
-            last if $count && ++$removed >= $count;
+            push @to_remove, $index;
+            $removed++;
+            last if $count && $removed >= $count;
         }
+    }
+
+    # reverse sort so that the higher indecies are removed first
+    for my $rm_idx (sort { $b <=> $a } @to_remove){
+        splice @{ $self->_stash->{$key} }, $rm_idx, 1;
     }
 
     return $removed;

--- a/t/50-lrem.t
+++ b/t/50-lrem.t
@@ -1,0 +1,81 @@
+#!perl
+
+use warnings;
+use strict;
+use lib 't/tlib';
+use Test::More;
+use Test::Fatal;
+use Test::Mock::Redis;
+
+ok(my $r = Test::Mock::Redis->new, 'pretended to connect to our test redis-server');
+my @redi = ($r);
+
+my ( $guard, $srv );
+if( $ENV{RELEASE_TESTING} ){
+    use_ok("Redis");
+    use_ok("Test::SpawnRedisServer");
+    ($guard, $srv) = redis();
+    ok(my $r = Redis->new(server => $srv), 'connected to our test redis-server');
+    $r->flushall;
+    unshift @redi, $r
+}
+
+foreach my $o (@redi){
+    diag("testing $o") if $ENV{RELEASE_TESTING};
+
+    my @lists = ( qw/ forward backward all / );
+
+    for my $lname ( @lists ) {
+        $o->rpush($lname, 'hello');
+        $o->rpush($lname, 'hello');
+        $o->rpush($lname, 'foo');
+        $o->rpush($lname, 'hello');
+
+        is_deeply(
+            [ $o->lrange($lname, 0, -1) ],
+            [ qw/
+              hello
+              hello
+              foo
+              hello
+            / ],
+            "list $lname as expected"
+        );
+    }
+
+    is( $o->lrem('forward', 2, 'hello'), 2, 'two removed from forward list' );
+
+    is_deeply(
+        [ $o->lrange('forward', 0, -1) ],
+        [ qw/
+          foo
+          hello
+        / ],
+        'forward list as expected'
+    );
+
+    is( $o->lrem('backward', -2, 'hello'), 2, 'two removed from backward list' );
+
+    is_deeply(
+        [ $o->lrange('backward', 0, -1) ],
+        [ qw/
+          hello
+          foo
+        / ],
+        'backward list as expected'
+    );
+
+    is( $o->lrem('all', 0, 'hello'), 3, '3 removed from all list' );
+
+    is_deeply(
+        [ $o->lrange('all', 0, -1) ],
+        [ qw/
+          foo
+        / ],
+        'all list as expected'
+    );
+}
+
+
+done_testing;
+


### PR DESCRIPTION
Found an issue in lrem, where due to it removing items (and therefore changing the length of the array) while still iterating over it, the 'eq' ended up looking at an undef value. This will also fix any issues where the value it would want to look at would have moved to the previous index, due to the array shrinking, and that value not being checked.

Also, yuo cannot create a range decreasing to 0, as when the left hand side of the range operator is greater, it creates an empty array. Instead, I've made it just reverse the array.

Added a test which checks that lrem works correctly.