### PR TITLE
Accept multiple values for LPUSH and RPUSH

### DIFF
--- a/lib/Test/Mock/Redis.pm
+++ b/lib/Test/Mock/Redis.pm
@@ -436,23 +436,32 @@ sub dbsize {
 }
 
 sub rpush {
-    my ( $self, $key, $value ) = @_;
+    my ( $self, $key, @values ) = @_;
+
+    confess "[rpush] ERR wrong number of arguments for 'rpush' command"
+        unless @values;
+
+    confess "[rpush] ERR Operation against a key holding the wrong kind of value"
+        unless !$self->exists($key) or $self->_is_list($key);
 
     $self->_make_list($key);
 
-    push @{ $self->_stash->{$key} }, "$value";
+    push @{ $self->_stash->{$key} }, map { "$_" } @values;
     return scalar @{ $self->_stash->{$key} };
 }
 
 sub lpush {
-    my ( $self, $key, $value ) = @_;
+    my ( $self, $key, @values ) = @_;
+
+    confess "[lpush] ERR wrong number of arguments for 'lpush' command"
+        unless @values;
 
     confess "[lpush] ERR Operation against a key holding the wrong kind of value"
         unless !$self->exists($key) or $self->_is_list($key);
 
     $self->_make_list($key);
 
-    unshift @{ $self->_stash->{$key} }, "$value";
+    unshift @{ $self->_stash->{$key} }, map { "$_" } @values;
     return scalar @{ $self->_stash->{$key} };
 }
 

--- a/t/09-list.t
+++ b/t/09-list.t
@@ -54,8 +54,11 @@ foreach my $r (@redi){
     is $r->llen('list'), 0, "llen returns 0 for a list that doesn't exist";
 
     for my $op (qw/lpush rpush/){
-        eval { $r->lpush('foo', 'barfoo') };
-        like $@, qr/^\Q[lpush] ERR Operation against a key holding the wrong kind of value\E/, "lpush against a key that doesn't hold a list died";
+        eval { $r->$op('foo', 'barfoo') };
+        like $@, qr/^\[$op\] ERR Operation against a key holding the wrong kind of value/, "$op against a key that doesn't hold a list died";
+
+        eval { $r->$op('foo') };
+        like $@, qr/^\[$op\] ERR wrong number of arguments for '$op' command/, "$op without any values died";
 
         ok ! $r->exists("list-$op"), "key 'list-$op' does not exist yet";
         is $r->$op("list-$op", 'foobar'), 1, "$op returns length of list";
@@ -66,6 +69,8 @@ foreach my $r (@redi){
         is $r->llen("list-$op"),          3, "llen agrees";
         is $r->$op("list-$op", 'quxqux'), 4, "$op returns length of list";
         is $r->llen("list-$op"),          4, "llen agrees";
+        is $r->$op("list-$op", 1,2,3,4),  8, "$op can add multiple values at once";
+        is $r->llen("list-$op"),          8, "llen agrees";
     }
 
     $r->rpush('list', $_) for 0..9;


### PR DESCRIPTION
See #25

Hey! Here's a stab at it. I tested some more in the command line client, and it looks like the number of values takes precedent over the key type.